### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,7 +16,7 @@ jobs:
       run: docker build . --file Dockerfile --tag go-mpnj:$(date +%s)
     
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         ## the name of our image
         name: ilhamsuryapratama/go-mpnj


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore